### PR TITLE
Add non-binary gender option with neutral styling

### DIFF
--- a/src/CreateTree/form.ts
+++ b/src/CreateTree/form.ts
@@ -58,7 +58,11 @@ export function createForm({
     label: 'Gender',
     initial_value: datum.data.gender,
     disabled: ['father', 'mother'].some(rel => rel === datum._new_rel_data?.rel_type) || childred_added,
-    options: [{value: 'M', label: 'Male'}, {value: 'F', label: 'Female'}]
+    options: [
+      {value: 'M', label: 'Male'},
+      {value: 'F', label: 'Female'},
+      {value: 'O', label: 'Other'}
+    ]
   }
 
   fields.forEach(field => {

--- a/src/styles/family-chart.css
+++ b/src/styles/family-chart.css
@@ -1,7 +1,7 @@
 .f3 {
   --female-color: rgb(196, 138, 146);
   --male-color: rgb(120, 159, 172);
-  --genderless-color: lightgray;
+  --genderless-color: gray;
   --background-color: rgb(33, 33, 33);
   --text-color: #fff;
 

--- a/src/view/elements/Form.ts
+++ b/src/view/elements/Form.ts
@@ -14,6 +14,7 @@ export function Form({datum, rel_datum, store, rel_type, card_edit, postSubmit, 
             <div>
               <label><input type="radio" name="gender" value="M" ${datum.data.gender === 'M' ? 'checked' : ''}><span>male</span></label><br>
               <label><input type="radio" name="gender" value="F" ${datum.data.gender === 'F' ? 'checked' : ''}><span>female</span></label><br>
+              <label><input type="radio" name="gender" value="O" ${datum.data.gender === 'O' ? 'checked' : ''}><span>other</span></label><br>
             </div>
           </div>
           ${getEditFields(card_edit)}


### PR DESCRIPTION
## Summary
- Allow selecting "Other" gender when creating or editing a person
- Display "Other" gender in forms and charts with a dark gray card

## Testing
- `npm run build` *(fails: Could not resolve entry module (rollup.config.js))*
- `npm test` *(fails: package not present in lockfile; run "yarn install")*


------
https://chatgpt.com/codex/tasks/task_e_6896d228889c8326920ac749eb42d8f6