### PR TITLE
feat: add living status and update styles

### DIFF
--- a/src/CreateTree/newPerson.ts
+++ b/src/CreateTree/newPerson.ts
@@ -74,7 +74,7 @@ export function handleRelsOfNewDatum({datum, data_stash, rel_type, rel_datum}) {
 }
 
 export function createNewPerson({data, rels}) {
-  return {id: generateUUID(), data: data || {}, rels: rels || {}}
+  return {id: generateUUID(), data: Object.assign({isLiving: true}, data || {}), rels: rels || {}}
 }
 
 export function createNewPersonWithGenderFromRel({data, rel_type, rel_datum}) {

--- a/src/styles/family-chart.css
+++ b/src/styles/family-chart.css
@@ -1,9 +1,10 @@
+
 .f3 {
-  --female-color: rgb(196, 138, 146);
-  --male-color: rgb(120, 159, 172);
+  --female-color: #ED4AA7;
+  --male-color: #03A2FE;
   --genderless-color: gray;
-  --background-color: rgb(33, 33, 33);
-  --text-color: #fff;
+  --background-color: #DEEBFE;
+  --text-color: #000;
 
   font-family: 'Roboto', sans-serif;
 }
@@ -27,6 +28,9 @@
 }
 .f3 rect.card-male, .f3 .card-male .card-body-rect, .f3 .card-male .text-overflow-mask {
   fill: var(--male-color);
+}
+.f3 rect.card-deceased, .f3 .card-deceased .card-body-rect, .f3 .card-deceased .text-overflow-mask {
+  fill: #000;
 }
 .f3 .card-genderless .card-body-rect, .f3 .card-genderless .text-overflow-mask {
   fill: var(--genderless-color);
@@ -84,6 +88,9 @@
 .f3 .card_break_link.closed .link_particles {
   transform: scale(0);
 }
+.f3 .card-deceased {
+  color: #fff;
+}
 .f3 .input-field input {
   height: 2.5rem !important;
 }
@@ -95,7 +102,7 @@
   width:100%;
   height:900px;
   max-height:70vh;
-  background-color: var(--background-color);
+  background: linear-gradient(#DEEBFE, #F2E8FF);
   color: var(--text-color);
 }
 .f3 {
@@ -290,6 +297,7 @@
   height: 100%;
   border-radius: 50%;
   object-fit: cover;
+  border: 2px solid gray;
 }
 
 .f3 div.card-image-circle svg {
@@ -298,6 +306,7 @@
   padding: 5px;
   border-radius: 50%;
   object-fit: cover;
+  border: 2px solid gray;
 }
 
 .f3 div.card-image-circle img {
@@ -335,6 +344,8 @@
   flex: 0 0 auto;
   padding: 5px;
   margin-right: 10px;
+  border-radius: 50%;
+  border: 2px solid gray;
 }
 
 .f3 div.card-image-rect img {
@@ -344,7 +355,8 @@
   flex: 0 0 auto;
   padding: 5px;
   margin-right: 10px;
-  border-radius: 8px;
+  border-radius: 50%;
+  border: 2px solid gray;
 }
 
 .f3 div.card-image-rect svg {
@@ -352,7 +364,8 @@
   width: 100%;
   height: 100%;
   padding: 5px;
-  border-radius: 7px;
+  border-radius: 50%;
+  border: 2px solid gray;
 }
 
 .f3 div.card-image-rect div.card-label {
@@ -453,6 +466,10 @@
 }
 .f3 div.card-genderless .card-inner, .f3 div.card-genderless .person-icon svg {
   background-color: var(--genderless-color);
+}
+.f3 div.card-deceased .card-inner, .f3 div.card-deceased .person-icon svg {
+  background-color: #000;
+  color: #fff;
 }
 
 .f3 div.card-new-rel .card-inner, .f3 div.card-new-rel .person-icon svg {

--- a/src/view/elements/Card.ts
+++ b/src/view/elements/Card.ts
@@ -10,7 +10,14 @@ export function Card(props) {
   setupCardSvgDefs(props.svg, props.card_dim)
 
   return function (d) {
-    const gender_class = d.data.data.gender === 'M' ? 'card-male' : d.data.data.gender === 'F' ? 'card-female' : 'card-genderless'
+    const gender_class =
+      d.data.data.isLiving === false
+        ? 'card-deceased'
+        : d.data.data.gender === 'M'
+        ? 'card-male'
+        : d.data.data.gender === 'F'
+        ? 'card-female'
+        : 'card-genderless'
     const card_dim = props.card_dim
 
     const card = d3.create('svg:g').attr('class', `card ${gender_class}`).attr('transform', `translate(${[-card_dim.w / 2, -card_dim.h / 2]})`)

--- a/src/view/elements/CardHtml.ts
+++ b/src/view/elements/CardHtml.ts
@@ -110,7 +110,8 @@ export function CardHtml(props) {
 
   function getClassList(d) {
     const class_list = []
-    if (d.data.data.gender === 'M') class_list.push('card-male')
+    if (d.data.data.isLiving === false) class_list.push('card-deceased')
+    else if (d.data.data.gender === 'M') class_list.push('card-male')
     else if (d.data.data.gender === 'F') class_list.push('card-female')
     else class_list.push('card-genderless')
 

--- a/src/view/elements/CardSvg.ts
+++ b/src/view/elements/CardSvg.ts
@@ -11,7 +11,14 @@ export function CardSvg(props) {
   setupCardSvgDefs(props.svg, props.card_dim)
 
   return function (d) {
-    const gender_class = d.data.data.gender === 'M' ? 'card-male' : d.data.data.gender === 'F' ? 'card-female' : 'card-genderless'
+    const gender_class =
+      d.data.data.isLiving === false
+        ? 'card-deceased'
+        : d.data.data.gender === 'M'
+        ? 'card-male'
+        : d.data.data.gender === 'F'
+        ? 'card-female'
+        : 'card-genderless'
     const card_dim = props.card_dim
 
     const card = d3.create('svg:g').attr('class', `card ${gender_class}`).attr('transform', `translate(${[-card_dim.w / 2, -card_dim.h / 2]})`)

--- a/src/view/elements/Link.ts
+++ b/src/view/elements/Link.ts
@@ -5,7 +5,7 @@ export default function Link({d, entering, exiting}) {
   const path = createPath(d, entering, exiting);
 
   return {template: (`
-    <path d="${path}" fill="none" stroke="#fff" />
+    <path d="${path}" fill="none" stroke="#D30002" />
   `)}
 }
 

--- a/src/view/view.links.ts
+++ b/src/view/view.links.ts
@@ -21,7 +21,7 @@ export default function updateLinks(svg, tree, props={}) {
   link_update.each(linkUpdate)
 
   function linkEnter(d) {
-    d3.select(this).attr("fill", "none").attr("stroke", "#fff").attr("stroke-width", 1).style("opacity", 0)
+    d3.select(this).attr("fill", "none").attr("stroke", "#D30002").attr("stroke-width", 1).style("opacity", 0)
       .attr("d", createPath(d, true))
   }
 


### PR DESCRIPTION
## Summary
- add `isLiving` person property and show black card for deceased
- refresh tree colors and gradient background
- round profile photos with gray borders and use red connection lines

## Testing
- `npm test` *(fails: This package doesn't seem to be present in your lockfile; run "yarn install" to update the lockfile)*

------
https://chatgpt.com/codex/tasks/task_e_689994acdd2c83268a06b454eb684f4f